### PR TITLE
Fix NaN for numeric input

### DIFF
--- a/src/regalia/js/Utilities.js
+++ b/src/regalia/js/Utilities.js
@@ -784,8 +784,8 @@ function SetRagsObjectsFromJavascript(resultval) {
 function CheckNumericLimits(tempvar, thevalue) {
     //check min/max limits...
     if (tempvar.bEnforceRestrictions) {
-        var themin = parseFloat(TheGame.PerformTextReplacements(tempvar.dMin, null));
-        var themax = parseFloat(TheGame.PerformTextReplacements(tempvar.dMax, null));
+        var themin = parseFloat(PerformTextReplacements(tempvar.dMin, null));
+        var themax = parseFloat(PerformTextReplacements(tempvar.dMax, null));
         if (parseFloat(thevalue) < themin)
             return themin;
         if (parseFloat(thevalue) > themax)


### PR DESCRIPTION
Unlike other parts of the code `CheckNumericLimits` uses `TheGame.PerformTextReplacement` instead of just `PerformTextReplacement` causing a `TypeError: TheGame.PerformTextReplacements is not a function` and the result ends up being NaN.